### PR TITLE
WP Ajaxify Comments: Update comment count bubble

### DIFF
--- a/frontend/inc/class-wpac.php
+++ b/frontend/inc/class-wpac.php
@@ -71,6 +71,10 @@
 			  .attr( \'name\', dataIncomKey ).val( $attDataIncomValue );
 			jQuery( idCommentsAndFormHash + \' .form-submit\' ).append( jQuery( input ) );
 
+			// Update count of bubble
+			var bubble = jQuery( ".incom-bubble-active a" );
+			bubble.text( parseInt( bubble.text(), 10 ) + 1 );
+
 		';
 
 	   return $wpacOptions;


### PR DESCRIPTION
After an inline comment is posted, the corresponding comment count bubble isn't updated to reflect the new count.

This commit should address this.
