### PR TITLE
Allow content and bubbles to be rebuilt

### DIFF
--- a/js/inline-comments.js
+++ b/js/inline-comments.js
@@ -82,6 +82,17 @@
 
 
 
+  /**
+   * Rebuild bubbles and content data attributes
+   */
+  incom.rebuild = function() {
+    $( '#incom_wrapper .incom-bubble' ).remove();
+    attDataIncomArr = [];
+    initElementsAndBubblesFromSelectors();
+  };
+
+
+
   /*
    * Private methods
    */


### PR DESCRIPTION
When combined with WP Front End Editor, this method allows Inline Comments functionality to be rebuilt so that it continues to function with the newly retrieved post content. FYI, the WP FEE post content itself [has to be filtered](https://github.com/cuny-academic-commons/social-paper/blob/master/assets/js/hooks-wp-fee.js#L95)  to strip out the `data-incom` attribute before WP FEE sends the data to the server.

The `rebuild()` method does not address the possibility of new relationships between the comments and the content. Nor does it address the possibility of orphaned comments when the number of selectors is reduced. However, I've noticed that Inline Comments itself doesn't check this either; i.e. if the corresponding element for the `data-incom-comment` value for a comment does not exist, the comment cannot be viewed. I'll try and suggest a solution to this at some point.
