### PR TITLE
Tweaks to rebuild() JS function

### DIFF
--- a/frontend/class-wp.php
+++ b/frontend/class-wp.php
@@ -27,6 +27,16 @@ class INCOM_WordPress extends INCOM_Frontend {
 	function load_incom() { ?>
 		<script>
 		(function ( $ ) {
+			var icTimer;
+
+			$(window).on( "resize", function() {
+			        clearTimeout( icTimer );
+
+			        icTimer = setTimeout( function() {
+					incom.rebuild();
+			        }, 100 );
+			} );
+
 			$(window).on( "load", function() {
 				incom.init({
 					selectors: '<?php if (get_option("multiselector") == '') { echo "p"; } else { echo get_option("multiselector"); } ?>',

--- a/js/inline-comments.js
+++ b/js/inline-comments.js
@@ -86,9 +86,20 @@
    * Rebuild bubbles and content data attributes
    */
   incom.rebuild = function() {
-    $( '#incom_wrapper .incom-bubble' ).remove();
+    // reset
+    $viewportW = $(window).width();
     attDataIncomArr = [];
+    $( '#incom_wrapper .incom-bubble' ).remove();
+
+    // re-init bubbles
     initElementsAndBubblesFromSelectors();
+
+    // reset sidebar form if visible
+    var commentsForm = $( idCommentsAndFormHash + ':visible' );
+    if ( commentsForm.length ) {
+        removeCommentsWrapper();
+        moveSite( 'out' );
+    }
   };
 
 


### PR DESCRIPTION
This PR does two things:
- Tweaks the `rebuild()` JS function to reset the viewport width and sidebar form.
- When the window is resized, `rebuild()` is called so the comment bubble positions are recalculated and the sidebar form is closed if open.  Previously, if the browser window was resized, the comment bubble would still be stuck at the same position.
