### PR TITLE
JS Fixes

### DIFF
--- a/frontend/class-wp.php
+++ b/frontend/class-wp.php
@@ -23,13 +23,15 @@ class INCOM_WordPress extends INCOM_Frontend {
 		(function ( $ ) {
 			var icTimer;
 
-			$(window).on( "resize", function() {
-			        clearTimeout( icTimer );
+			$(function(){
+				$(window).on( "resize", function() {
+				        clearTimeout( icTimer );
 
-			        icTimer = setTimeout( function() {
-					incom.rebuild();
-			        }, 100 );
-			} );
+				        icTimer = setTimeout( function() {
+						incom.rebuild();
+				        }, 100 );
+				} );
+			});
 
 			$(window).on( "load", function() {
 				incom.init({

--- a/frontend/inc/class-wpac.php
+++ b/frontend/inc/class-wpac.php
@@ -87,6 +87,8 @@
 			} else {
 				bubble.text(1);
 			}
+
+			bubble.parent().addClass("incom-bubble-static").css("display","block");
 		';
 
 	   return $wpacOptions;

--- a/js/inline-comments.js
+++ b/js/inline-comments.js
@@ -137,7 +137,7 @@
             i,
             l;
         
-        elementsBySelectors = document.querySelectorAll(o.selectors);   
+        elementsBySelectors = $( o.selectors );
         for (i = 0, l = elementsBySelectors.length; i < l; i += 1) {
             var $that = $(elementsBySelectors[i]);
             addAttToElement($that);


### PR DESCRIPTION
Hi Kevin,

This PR fixes a few JS issues:
- Commit 01518f3 fixes a JS issue where if an admin passes a jQuery selector to the "Selectors" option on the Inline Comments settings page, the frontend JS would fail and comment bubbles would not appear as a result; this used to work before v2.2.1.  The problem is due to the change to replace jQuery with document.querySelectorAll() in commit eecd08e.
- Commit 9e0184b fixes a minor bug that was introduced by me for the resize handler (see commit 2f8d7ed).  Resize hook should be added only after the document is loaded.

Props to @boonebgorges for discovering these bugs and finding fixes for them.

**Update:**

Commit 22a966e fixes an issue with WP Ajaxify Comments where after a new comment is added to a paragraph with no count and you hover elsewhere, the comment bubble for the new comment is hidden.  The commit fixes this by adding the `incom-bubble-static` class to the new comment block.
